### PR TITLE
updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - A new small-world network styling method based on 1d lattice distance (in epipack.networks)
 - methods to compute Jacobian and next generation matrices (NGMs) in `MatrixEpiModel`, as well as R0 from said NGMs (TODO: add docs)
-- `epipack.distributions` module, which deals with fitting empirical distributions to sums of exponentially distributed random variables
-- methods to `EpiModel` that save events that have been set. This will be used to generate model flowcharts with graphviz
+- tests for these methods
+- `epipack.distributions` module, which deals with fitting empirical distributions to sums of exponentially distributed random variables (still in dev mode, also TODO: add docs)
+- methods to `EpiModel` that save events that have been set. This will be used to generate model flowcharts with graphviz at some point
 
 ## [v0.1.3] - 2020-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `epipack.distributions` module, which deals with fitting empirical distributions to sums of exponentially distributed random variables (still in dev mode, also TODO: add docs)
 - tests for this module
 - methods to `EpiModel` that save events that have been set. This will be used to generate model flowcharts with graphviz at some point
+- the possibility to pass a function to ``StochasticEpiModel.simulate`` that checks for a custom stop condition
 
 ## [v0.1.3] - 2020-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - methods to compute Jacobian and next generation matrices (NGMs) in `MatrixEpiModel`, as well as R0 from said NGMs (TODO: add docs)
 - tests for these methods
 - `epipack.distributions` module, which deals with fitting empirical distributions to sums of exponentially distributed random variables (still in dev mode, also TODO: add docs)
+- tests for this module
 - methods to `EpiModel` that save events that have been set. This will be used to generate model flowcharts with graphviz at some point
 
 ## [v0.1.3] - 2020-04-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [v0.1.4] - 2020-05-18
+
 ### Added
 
 - A new small-world network styling method based on 1d lattice distance (in epipack.networks)
@@ -97,7 +99,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - initialized
 
-[Unreleased]: https://github.com/benmaier/epipack/compare/v0.1.3...HEAD
+[Unreleased]: https://github.com/benmaier/epipack/compare/v0.1.4...HEAD
+[v0.1.4]: https://github.com/benmaier/epipack/compare/v0.1.2...v0.1.4]
 [v0.1.3]: https://github.com/benmaier/epipack/compare/v0.1.2...v0.1.3]
 [v0.1.2]: https://github.com/benmaier/epipack/compare/v0.1.1...v0.1.2]
 [v0.1.1]: https://github.com/benmaier/epipack/compare/v0.1.0...v0.1.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A new small-world network styling method based on 1d lattice distance (in epipack.networks)
 - methods to compute Jacobian and next generation matrices (NGMs) in `MatrixEpiModel`, as well as R0 from said NGMs (TODO: add docs)
 - `epipack.distributions` module, which deals with fitting empirical distributions to sums of exponentially distributed random variables
 - methods to `EpiModel` that save events that have been set. This will be used to generate model flowcharts with graphviz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- methods to compute Jacobian and next generation matrices (NGMs) in `MatrixEpiModel`, as well as R0 from said NGMs (TODO: add docs)
+- `epipack.distributions` module, which deals with fitting empirical distributions to sums of exponentially distributed random variables
+- methods to `EpiModel` that save events that have been set. This will be used to generate model flowcharts with graphviz
+
 ## [v0.1.3] - 2020-04-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ So far, the package's functionality was tested on Mac OS X and CentOS only.
 * `sympy==1.6`
 * `pyglet<1.6`
 * `matplotlib>=3.0.0`
-* `bfmplot>=0.0.7`
 * `ipython>=7.14.0`
 * `ipywidgets>=7.5.1`
 

--- a/README.rst
+++ b/README.rst
@@ -101,7 +101,6 @@ installed by ``pip`` during the installation process
 -  ``sympy==1.6``
 -  ``pyglet<1.6``
 -  ``matplotlib>=3.0.0``
--  ``bfmplot>=0.0.7``
 -  ``ipython>=7.14.0``
 -  ``ipywidgets>=7.5.1``
 

--- a/cookbook/modular_hierarchical_network_reaction_diffusion/sw_layout_reaction_diffusion_simple_vis.py
+++ b/cookbook/modular_hierarchical_network_reaction_diffusion/sw_layout_reaction_diffusion_simple_vis.py
@@ -1,0 +1,72 @@
+from epipack import MatrixEpiModel, get_2D_lattice_links
+from epipack.vis import visualize_reaction_diffusion, get_grid_layout
+import numpy as np
+import networkx as nx
+import cMHRN
+from time import time
+from epipack.networks import get_small_world_layout
+
+# load edges from txt file and construct Graph object
+N, edges = cMHRN.fast_mhrn(8,3,7,0.18,True)
+
+
+
+start = time()
+
+# get the network properties
+links = [ ( u, v, 1.0 ) for u, v in edges ]
+
+network = get_small_world_layout(N,links)
+
+
+
+
+
+
+base_compartments = "SIR"
+
+compartments = [ (node, C) for node in range(N) for C in base_compartments ]
+model = MatrixEpiModel(compartments)
+
+infection_rate = 3
+recovery_rate = 1
+mobility_rate = 0.05
+
+quadratic_processes = []
+linear_processes = []
+
+print("defining processes")
+
+for node in range(N):
+    quadratic_processes.append(
+            (  (node, "S"), (node, "I"), infection_rate, (node, "I"), (node, "I") ),
+        )
+
+    linear_processes.append(
+              ( (node, "I"), recovery_rate, (node, "R") ) 
+        )
+
+for u, v, w in links:
+    for C in base_compartments:
+
+        linear_processes.extend([
+                  ( (u, C), w*mobility_rate, (v, C) ),
+                  ( (v, C), w*mobility_rate, (u, C) ),
+            ])
+
+print("set processes")
+
+model.set_processes(quadratic_processes+linear_processes,allow_nonzero_column_sums=True)
+
+initial_conditions = { ( node, "S" ): 1.0 for node in range(N) } 
+initial_conditions[(0, "S")] = 0.8
+initial_conditions[(0, "I")] = 0.2
+model.set_initial_conditions(initial_conditions,allow_nonzero_column_sums=True)
+
+t = np.linspace(0,20,100)
+
+node_compartments = [ (node, "I" ) for node in range(N) ]
+
+dt = 0.04
+visualize_reaction_diffusion(model, network, dt, node_compartments, value_extent=[0,0.3])
+

--- a/docs/about.rst
+++ b/docs/about.rst
@@ -103,7 +103,6 @@ installed by ``pip`` during the installation process
 -  ``sympy==1.6``
 -  ``pyglet<1.6``
 -  ``matplotlib>=3.0.0``
--  ``bfmplot>=0.0.7``
 -  ``ipython>=7.14.0``
 -  ``ipywidgets>=7.5.1``
 

--- a/docs/api/distributions.rst
+++ b/docs/api/distributions.rst
@@ -1,0 +1,8 @@
+Distributions
+-------------
+
+.. automodule:: epipack.distributions
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'epipack'
-copyright = u'2020,  Benjamin F. Maier'
+copyright = u'2020-2021,  Benjamin F. Maier'
 author = u' Benjamin F. Maier'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ epipack
    api/numeric_matrix_epi_models
    api/symbolic_matrix_epi_models
    api/plottools
+   api/distributions
 
 .. .. toctree::
 ..    :maxdepth: 2

--- a/epipack/distributions.py
+++ b/epipack/distributions.py
@@ -279,7 +279,7 @@ def fit_chain_by_cdf(n,time_values,cdf,lower=1e-10,upper=1e10,percentile_cutoff=
     =======
 
     >>> median, iqr = 13.184775302968362, ( 7.81098765, 20.86713744)
-    >>> fit_C = fit_chain_by_median_and_iqr(3,median,iqr)
+    >>> fit_C = fit_chain_by_cdf(3,[iqr[0], median, iqr[1]],[0.25,0.5,0.75])
     >>> fit_C.get_median_and_iqr()
     13.183969129892406, array([ 7.8109697 , 20.86699702])
     >>> fit_C.tau

--- a/epipack/distributions.py
+++ b/epipack/distributions.py
@@ -1,0 +1,336 @@
+"""
+Module to fit duration distributions to sums of exponential functions.
+"""
+import numpy as np
+from scipy.sparse import csr_matrix
+from scipy.integrate import solve_ivp
+from scipy.optimize import minimize
+from scipy.stats import entropy
+
+_DEFAULT_METHOD = 'RK23'
+
+def integrate_euler(dydt, dt, y0, percentile_cutoff, *args):
+    """
+    Integrate an ODE system with Euler's method.
+
+    Parameters
+    ----------
+    dydt : function
+        A function returning the momenta of the ODE system.
+    t : numpy.ndarray of float
+        Array of time points at which the functions should
+        be evaluated.
+    y0 : numpy.ndarray
+        Initial conditions
+    *args : :obj:`list`
+        List of parameters that will be passed to the
+        momenta function.
+    """
+
+    # get copy
+    y0 = np.array(y0,dtype=float)
+    y = y0
+
+    # initiate integrator
+    result = [y0]
+    nt = 1
+
+    while y[-1] < percentile_cutoff:
+
+            # get result of ODE integration
+            y = y + dt * dydt(None,y)
+
+            # write result to result vector
+            result.append(y)
+
+            nt += 1
+
+    t = np.arange(nt,dtype=float) * dt
+
+    return t, np.array(result)
+
+class chain():
+
+    def __init__(self,n,durations):
+
+        if n != int(n):
+            raise ValueError("`n` must be integer, but is " + str(n))
+        self.n = int(n)
+
+        if int(n) != len(durations):
+            raise ValueError("`durations` must have the same length as n = "+str(n)+" but has len = " + str(len(durations)))
+        self.tau = durations
+        self.n_st = int(n) + 1
+        self.dt = min(durations) / 50.
+
+        data = []
+        rows = []
+        cols = []
+
+        for i in range(self.n):
+            src = i
+            trg = i+1
+            rows.append(trg)
+            cols.append(src)
+            data.append(1/self.tau[i])
+            rows.append(src)
+            cols.append(src)
+            data.append(-1/self.tau[i])
+
+        self.W = csr_matrix((data, (rows, cols)), shape=2*[self.n_st])
+
+    def dydt(self,t,y):
+        return self.W.dot(y)
+
+    def get_cdf_euler(self,dt=None,percentile_cutoff=0.9999):
+
+        if dt is None:
+            dt = self.dt
+
+        y0 = np.zeros(self.n_st)
+        y0[0] = 1.0
+
+        t, y = integrate_euler(self.dydt,dt,y0,percentile_cutoff)
+
+        return t, y[:,-1]
+
+    def get_cdf(self,t=None,percentile_cutoff=0.9999,method=_DEFAULT_METHOD):
+
+        y0 = np.zeros(self.n_st)
+        y0[0] = 1.0
+
+        stop_condition = lambda t, y: percentile_cutoff - y[-1]
+        stop_condition.terminal = True
+
+        result = solve_ivp(
+                            fun=self.dydt,
+                            y0=y0,
+                            t_eval=t,
+                            t_span=(0,np.inf),
+                            events=stop_condition,
+                            method=method,
+                          )
+
+
+        return result.t, result.y[-1,:]
+
+    def get_pdf(self,t=None,percentile_cutoff=0.9999,method=_DEFAULT_METHOD):
+        t, P = self.get_cdf(t=t,percentile_cutoff=percentile_cutoff,method=method)
+        dt = np.diff(t)
+        dP = np.diff(P)
+        tmean = 0.5*(t[1:]+t[:-1])
+        return tmean, dP/dt, dt
+
+    def get_cdf_at_percentiles(self,percentiles,method=_DEFAULT_METHOD):
+
+        y0 = np.zeros(self.n_st)
+        y0[0] = 1.0
+        time_values = np.zeros_like(percentiles)
+        t = 0
+
+        for i, P in enumerate(percentiles):
+
+            stop_condition = lambda t, y: P - y[-1]
+            stop_condition.terminal = True
+
+            result = solve_ivp(
+                                fun=self.dydt,
+                                y0=y0,
+                                t_span=(t,np.inf),
+                                events=stop_condition,
+                                method=method,
+                              )
+
+            y0 = result.y[:,-1]
+            t = result.t[-1]
+            time_values[i] = t
+
+        return time_values, percentiles
+
+    def get_median_and_iqr(self,method=_DEFAULT_METHOD):
+
+        percentiles = [0.25,0.5,0.75]
+
+        time_values, _ = self.get_cdf_at_percentiles(percentiles,method=method)
+
+        return time_values[1], time_values[[0,2]]
+
+    def get_mean(self):
+        return sum(self.tau)
+
+def fit_chain_by_cdf(n,time_values,cdf,lower=1e-10,upper=1e10,percentile_cutoff=1-1e-15,x0=None):
+
+    if n != int(n):
+        raise ValueError("`n` must be integer, but is " + str(n))
+
+    dQ = np.diff(cdf)
+
+    cdf = np.array(cdf)
+
+    if x0 is None:
+        mean = (np.diff(np.concatenate((np.array([0]),time_values))) * (1 - cdf)).sum()
+        x0 = [mean/n] * n
+
+    def cost(x, n, cdf, time_values, percentile_cutoff):
+        C  = chain(n,x)
+        _, P = C.get_cdf(time_values,percentile_cutoff=percentile_cutoff)
+        if len(P) < len(cdf):
+            P = np.concatenate((P,np.ones(len(cdf)-len(P))))
+        #return ( ((cdf - P)/cdf)**2).sum()
+        return ( ((cdf - P)/cdf)**2).sum()
+        #return max(np.abs(cdf - P))
+        #return ( ((percentiles - P))**2).sum()
+        #dP = np.diff(P)
+        #return entropy(np.diff(P), dQ)
+
+
+    result = minimize(cost, x0, (n, cdf, time_values, percentile_cutoff), bounds=[(lower,upper)]*n)
+
+    return chain(n, result.x)
+
+
+def fit_chain_by_median_and_iqr(n,median,iqr,lower=1e-10,upper=1e10):
+    percentiles = np.array([0.25,0.5,0.75])
+    time_values = np.array([iqr[0],median,iqr[1]])
+    mean = median
+    x0 = [mean/n]*n
+    return fit_chain_by_cdf(n,time_values,percentiles,lower,upper,x0=x0)
+
+
+if __name__ == "__main__":
+    import matplotlib.pyplot as pl
+    from scipy.stats import erlang
+
+    n = 10
+    mean = 10
+    C = chain(n,[mean/n]*n)
+    E = erlang(a=n,scale=mean/n)
+
+    t, y = C.get_cdf()
+
+    pl.plot(t, y)
+    pl.plot(t, E.cdf(t))
+
+    print(C.get_median_and_iqr())
+    print(E.median(), E.interval(0.5))
+    pl.show()
+
+
+    # =========
+    n = 4
+    C = chain(n, [0.3,6.,9,0.4])
+    fit_C = fit_chain_by_median_and_iqr(3,*C.get_median_and_iqr())
+
+    print("C med iqr =",C.get_median_and_iqr())
+    print("fit med iqr =",fit_C.get_median_and_iqr())
+    print("C durs =",C.tau)
+    print("fit durs =",fit_C.tau)
+
+    fig, ax = pl.subplots(1,2,figsize=(8,4))
+    for ch in [C, fit_C]:
+        t, P = ch.get_cdf()
+        dP = np.diff(P)
+        tmean = 0.5*(t[1:] + t[:-1])
+        dt = np.diff(t)
+        ax[1].bar(tmean, dP/dt,width=dt,alpha=0.5)
+        ax[0].plot(t,P)
+        print(sum(dP))
+
+    pl.show()
+
+
+    # ==================
+
+    data = np.array([
+    [0.9782608695652173, 0.6117433930093777],
+    [1.9565217391304341, 0.7045325376527423],
+    [2.934782608695652, 0.7829425973287867],
+    [3.9673913043478257, 0.789456048119731],
+    [4.945652173913045, 0.8064281992990434],
+    [5.923913043478262, 0.7698055792365256],
+    [6.9565217391304355, 0.7266458274130909],
+    [7.934782608695654, 0.6691081746708346],
+    [8.967391304347826, 0.6115693378800797],
+    [9.945652173913045, 0.5474957374254049],
+    [10.923913043478263, 0.4781933788007957],
+    [11.956521739130435, 0.4245761106374918],
+    [12.880434782608697, 0.3539677465188974],
+    [13.96739130434783, 0.29773491522212747],
+    [14.945652173913045, 0.24411883110732224],
+    [15.923913043478263, 0.19703869470493518],
+    [17.01086956521739, 0.15518494837548535],
+    [17.934782608695652, 0.1342497868712702],
+    [18.913043478260867, 0.09893435635123615],
+    [19.945652173913043, 0.07799682675002373],
+    [20.92391304347826, 0.06098204982476085],
+    [21.956521739130434, 0.04658046793596648],
+    [22.934782608695652, 0.030872880553187487],
+    [24.07608695652174, 0.028233636449748856],
+    [25, 0.016448801742919406],
+    [25.978260869565215, 0.01119873070000943],
+    [26.902173913043477, 0.011178601875532879],
+    [27.989130434782606, 0.007233352278109395],
+    [28.804347826086957, 0.007215591550630007],
+    [29.945652173913047, 0.004576347447191376],
+    [31.03260869565218, 0.003245476934735203],
+    [31.902173913043477, 0.0032265321587572338],
+    [32.93478260869565, 0.003204035237283298],
+    [33.96739130434783, -0.000740030311641604],
+    [35, -0.0007625272331155397],
+    [36.141304347826086, 0.0005197972908970172],
+    [37.22826086956522, 0.0004961163209245001],
+    [38.15217391304348, 0.00047598749644794935],
+    [39.07608695652174, 0.001763048214454832],
+    [39.94565217391305, -0.0008702756464904482],
+    [40.869565217391305, 0.0004167850715164345],
+    [41.79347826086956, 0.0017038457895235393],
+    [42.93478260869565, -0.0009353983139148703],
+    [43.96739130434783, -0.0009578952353888059],
+    [44.94565217391305, 0.0003279814341194953],
+    ])
+    t = np.round(data[:,0])
+    print(t)
+    P = data[:,1]
+    P[P<0] = 0
+    P /= P.sum()
+    CDF = np.cumsum(P)
+    fig, ax = pl.subplots(1,2,figsize=(8,4))
+    ax[0].plot(t, CDF)
+    ax[1].bar(t, P,alpha=0.4)
+    ch = fit_chain_by_cdf(3,t,CDF,lower=0.1,upper=50,x0=[1.29,3.37,4.01])
+    #ch = fit_chain_by_cdf(8,t,CDF,lower=0.1,upper=50)
+    t, dPdt, width = ch.get_pdf()
+    ax[1].bar(t, dPdt, width=width,alpha=0.4)
+    ax[0].plot(*ch.get_cdf(t))
+
+    pl.show()
+
+
+
+    # ===========
+
+    med_iqr = [
+                ( 5, ( 2, 13)),
+                (11, ( 6, 21)),
+                (10, ( 4, 19)),
+                ( 6, ( 3, 11)),
+                ( 9, ( 4, 18)),
+            ]
+
+    for med, iqr in med_iqr:
+        fit_C = fit_chain_by_median_and_iqr(3,med,iqr,lower=0.1,upper=100)
+        print("demanded med and iqr =", med, iqr)
+        print("fitted   med and iqr =", fit_C.get_median_and_iqr())
+        print("fitted durations =",fit_C.tau)
+        print()
+        fig, ax = pl.subplots(1,2,figsize=(8,4))
+        ax[0].plot(*fit_C.get_cdf())
+        t, dPdt, width = fit_C.get_pdf()
+        ax[1].bar(t, dPdt, width=width)
+
+    pl.show()
+
+
+
+
+

--- a/epipack/metadata.py
+++ b/epipack/metadata.py
@@ -3,10 +3,10 @@
 Contains a bunch of information about this package.
 """
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 __author__ = "Benjamin F. Maier"
-__copyright__ = "Copyright 2020, " + __author__
+__copyright__ = "Copyright 2020-2021, " + __author__
 __credits__ = [__author__]
 __license__ = "MIT"
 __maintainer__ = __author__

--- a/epipack/networks.py
+++ b/epipack/networks.py
@@ -215,7 +215,13 @@ def get_small_world_layout(
                       ):
     """
     Returns a stylized network dictionary that puts
-    nodes in a random layout.
+    nodes in a small-world inspired circular layout.
+    The ring of nodes will be drawn bouncy
+    to better display connections between nearby regions.
+    Nodes that connect far-away regions of a network
+    will be displayed more centrally.
+    Distance is defined as lattice distance by integer
+    node id. Hence, nodes must be integers in [0,N).
 
     Parameters
     ==========

--- a/epipack/networks.py
+++ b/epipack/networks.py
@@ -8,6 +8,9 @@ def _edge(u,v,w):
     u, v = sorted([u,v])
     return u, v, w
 
+def _dist(i,j,N):
+    return min(np.abs(i-j), N-np.abs(i-j))
+
 def get_2D_lattice_links(N_side,periodic=False,diagonal_links=False):
     """
     Return the links of a square 2D lattice
@@ -30,7 +33,7 @@ def get_2D_lattice_links(N_side,periodic=False,diagonal_links=False):
                 v = i*N_side + ( (j+1) % N_side )
                 links.append(_edge(u,v,1.0))
             if periodic or i+1 < N_side:
-                v = ((i+1) % N_side)*N_side + j 
+                v = ((i+1) % N_side)*N_side + j
                 links.append(_edge(u,v,1.0))
 
             if diagonal_links:
@@ -48,7 +51,7 @@ def get_2D_lattice_links(N_side,periodic=False,diagonal_links=False):
 
 def get_grid_layout(N_nodes,edge_weight_tuples=[],windowwidth=400,linkwidth=1):
     """
-    Returns a stylized network dictionary that puts 
+    Returns a stylized network dictionary that puts
     nodes in a grid layout.
 
     Parameters
@@ -67,7 +70,7 @@ def get_grid_layout(N_nodes,edge_weight_tuples=[],windowwidth=400,linkwidth=1):
 
     windowwidth : float, default = 400
         The width of the network visualization
-    linkwidth : float, default = 1.0 
+    linkwidth : float, default = 1.0
         All links get the same width.
 
     Returns
@@ -112,7 +115,7 @@ def get_random_layout(N_nodes,
                       circular=True,
                       ):
     """
-    Returns a stylized network dictionary that puts 
+    Returns a stylized network dictionary that puts
     nodes in a random layout.
 
     Parameters
@@ -131,12 +134,12 @@ def get_random_layout(N_nodes,
 
     windowwidth : float, default = 400
         The width of the network visualization
-    linkwidth : float, default = 1.0 
+    linkwidth : float, default = 1.0
         All links get the same width.
     node_scale_by_degree : float, default = 0.5
         Scale the node radius by ``degree**node_scale_by_degree``.
         Per default, the node disk area will be
-        proportional to the degree. If you want 
+        proportional to the degree. If you want
         all nodes to be equally sized, set
         ``node_scale_by_degree = 0``.
     circular : bool, default = True
@@ -184,6 +187,122 @@ def get_random_layout(N_nodes,
         pos[:,0] = r*np.cos(t) + w/2
         pos[:,1] = r*np.sin(t) + w/2
 
+
+    nodes = [ {
+                'id': i,
+                'x_canvas': pos[0],
+                'y_canvas': pos[1],
+                'radius': radius[i],
+              } for i, pos in enumerate(pos)]
+    nodes = nodes[:N_nodes]
+    links = [ {'source': u, 'target': v, 'width': linkwidth} for u, v, w in edge_weight_tuples ]
+
+    stylized_network['nodes'] = nodes
+    stylized_network['links'] = links
+
+
+    return stylized_network
+
+def get_small_world_layout(
+                      N_nodes,
+                      edge_weight_tuples=[],
+                      windowwidth=400,
+                      linkwidth=1,
+                      node_scale_by_degree=2,
+                      nbounce=20,
+                      Rbounce=0.1,
+                      R=0.8,
+                      ):
+    """
+    Returns a stylized network dictionary that puts
+    nodes in a random layout.
+
+    Parameters
+    ==========
+    N_nodes : int
+        The number of nodes in the network
+    edge_weight_tuples : list, default = []
+        A list of tuples. Each tuple describes an edge
+        with the first entry being the source node index,
+        the second entry being the target node index
+        and the third entry being the weight, e.g.
+
+        .. code:: python
+
+            [ (0, 1, 1.0) ]
+
+    windowwidth : float, default = 400
+        The width of the network visualization
+    linkwidth : float, default = 1.0
+        All links get the same width.
+    node_scale_by_degree : float, default = 2
+        Scale the node radius by ``degree**node_scale_by_degree``.
+        If you want
+        all nodes to be equally sized, set
+        ``node_scale_by_degree = 0``.
+    nbounce : int, default = 20
+        How wobbly the outer shell should be.
+    Rbounce : int, default = 0.1
+        How thick the outer shell should be
+        (in units of half window width)
+    R : float, default = 0.8
+        How large the radius of the whole layout should be
+        (in units of half window width)
+
+    Returns
+    =======
+    network : dict
+        A stylized network dictionary in netwulf-format.
+    """
+
+    w = h = windowwidth
+    N = N_nodes
+    N_side = int(np.ceil(np.sqrt(N)))
+    dx = w / N_side
+    radius = dx/3
+
+    Rbounce /= R
+    R = R * w/2
+    Rbounce *= R
+
+    network = {}
+    stylized_network = {
+        'xlim': [0, w],
+        'ylim': [0, h],
+        'linkAlpha': 0.5,
+        'nodeStrokeWidth': 0.0001,
+    }
+
+    degree = np.zeros(N,)
+    node_distances = [[] for n in range(N)]
+    for u, v, _w in edge_weight_tuples:
+        node_distances[u].append(_dist(u,v,N))
+        node_distances[v].append(_dist(u,v,N))
+        degree[u] += 1
+        degree[v] += 1
+
+    median_degree = np.median(degree)
+    if median_degree == 0:
+        median_degree = 1
+    radius_scale = (degree/median_degree)**node_scale_by_degree
+    radius_scale[radius_scale==0] = 1.0
+    radius = radius_scale * radius
+
+    node_distance_maxs = [ np.max(dists+[0]) for dists in node_distances ]
+    distance_measure = node_distance_maxs
+
+    dphi = 2*np.pi/N
+    maxmean = 3*N/4
+
+    pos = np.zeros((N, 2))
+
+    for n in range(N):
+        phi = n*dphi
+        rbase = R+Rbounce*np.sin(nbounce*phi)
+        r = rbase*(1-distance_measure[n]/maxmean)
+        x = r*np.cos(phi) + w/2
+        y = r*np.sin(phi) + w/2
+        pos[n,:] = x, y
 
     nodes = [ {
                 'id': i,

--- a/epipack/numeric_epi_models.py
+++ b/epipack/numeric_epi_models.py
@@ -768,7 +768,7 @@ class EpiModel(IntegrationMixin):
 
             quadratic_event_updates.append( dy )
             quadratic_rate_functions.append( this_rate )
-            quadratic_events.append( coupling_compartments, rate, affected_compartments )
+            quadratic_events.append( (coupling_compartments, rate, affected_compartments) )
 
         if not allow_nonzero_column_sums and len(quadratic_rate_functions)>0:
             _y = np.ones(self.N_comp)

--- a/epipack/numeric_epi_models.py
+++ b/epipack/numeric_epi_models.py
@@ -281,6 +281,11 @@ class EpiModel(IntegrationMixin):
         self.linear_event_updates = []
         self.quadratic_rate_functions = []
         self.quadratic_event_updates = []
+
+        self.birth_events = []
+        self.linear_events = []
+        self.quadratic_events = []
+
         self.use_ivp_solver = integral_solver == 'solve_ivp'
 
         self.rates_have_explicit_time_dependence = False
@@ -430,11 +435,16 @@ class EpiModel(IntegrationMixin):
             birth_event_updates = []
             linear_rate_functions = []
             linear_event_updates = []
+            birth_events = []
+            linear_events = []
         else:
-            linear_event_updates = self.linear_event_updates
-            birth_event_updates = self.birth_event_updates
-            linear_rate_functions = self.linear_rate_functions
-            birth_rate_functions = self.birth_rate_functions
+            linear_event_updates = list(self.linear_event_updates)
+            birth_event_updates = list(self.birth_event_updates)
+            linear_rate_functions = list(self.linear_rate_functions)
+            birth_rate_functions = list(self.birth_rate_functions)
+            birth_events = list(self.birth_events)
+            linear_events = list(self.linear_events)
+
 
         for acting_compartments, rate, affected_compartments in event_list:
 
@@ -450,6 +460,7 @@ class EpiModel(IntegrationMixin):
                     this_rate = ConstantBirthRate(rate)
                 birth_event_updates.append( dy )
                 birth_rate_functions.append( this_rate )
+                birth_events.append((acting_compartments, rate, affected_compartments))
             else:
                 _s = self.get_compartment_id(acting_compartments[0])
                 if self._rate_has_functional_dependency(rate):
@@ -458,6 +469,7 @@ class EpiModel(IntegrationMixin):
                     this_rate = ConstantLinearRate(rate, _s)
                 linear_event_updates.append( dy )
                 linear_rate_functions.append( this_rate )
+                linear_events.append((acting_compartments, rate, affected_compartments))
 
             if dy.sum() != 0 and not self.correct_for_dynamical_population_size:
                 warnings.warn("This model has processes with a fluctuating "+\
@@ -477,6 +489,8 @@ class EpiModel(IntegrationMixin):
         self.linear_rate_functions = linear_rate_functions
         self.birth_event_updates = birth_event_updates
         self.birth_rate_functions = birth_rate_functions
+        self.linear_events = linear_events
+        self.birth_events = birth_events
 
         return self
 
@@ -672,7 +686,7 @@ class EpiModel(IntegrationMixin):
                                       reset_events=False,
                                       allow_nonzero_column_sums=allow_nonzero_column_sums
                                       )
-    
+
     def set_quadratic_events(self,
                              event_list,
                              allow_nonzero_column_sums=False,
@@ -690,7 +704,7 @@ class EpiModel(IntegrationMixin):
 
                 [
                     (
-                        ("coupling_compartment_0", "coupling_compartment_1"), 
+                        ("coupling_compartment_0", "coupling_compartment_1"),
                         rate,
                         [
                             ("affected_compartment_0", dN0),
@@ -716,25 +730,27 @@ class EpiModel(IntegrationMixin):
 
             epi.set_quadratic_events([
                 ( ("S", "I"),
-                  eta, 
-                  [ ("S", -1), ("E", +1) ] 
+                  eta,
+                  [ ("S", -1), ("E", +1) ]
                 ),
             ])
 
         Read  as
 
         "Coupling of *S* and *I* leads to
-        the decay of one *S* particle to one *E* particle with 
+        the decay of one *S* particle to one *E* particle with
         rate :math:`\eta`.".
         """
 
         if reset_events:
             quadratic_event_updates = []
             quadratic_rate_functions = []
+            quadratic_events = []
         else:
-            quadratic_event_updates = self.quadratic_event_updates
-            quadratic_rate_functions = self.quadratic_rate_functions
-        
+            quadratic_event_updates = list(self.quadratic_event_updates)
+            quadratic_rate_functions = list(self.quadratic_rate_functions)
+            quadratic_events = list(self.quadratic_events)
+
         for coupling_compartments, rate, affected_compartments in event_list:
 
             _s0 = self.get_compartment_id(coupling_compartments[0])
@@ -752,6 +768,7 @@ class EpiModel(IntegrationMixin):
 
             quadratic_event_updates.append( dy )
             quadratic_rate_functions.append( this_rate )
+            quadratic_events.append( coupling_compartments, rate, affected_compartments )
 
         if not allow_nonzero_column_sums and len(quadratic_rate_functions)>0:
             _y = np.ones(self.N_comp)
@@ -762,6 +779,7 @@ class EpiModel(IntegrationMixin):
 
         self.quadratic_event_updates = quadratic_event_updates
         self.quadratic_rate_functions = quadratic_rate_functions
+        self.quadratic_events = quadratic_events
 
         return self
 
@@ -896,8 +914,8 @@ class EpiModel(IntegrationMixin):
     def get_event_rates(self, t, y):
         """
         Get a list of rate values corresponding to the previously
-        set events. 
-        
+        set events.
+
         Parameters
         ----------
         t : float
@@ -909,7 +927,7 @@ class EpiModel(IntegrationMixin):
         -------
         rates : list
             A list of rate values corresponding to rates.
-            Ordered as ``birth_rate_functions + 
+            Ordered as ``birth_rate_functions +
             linear_rate_functions + quadratic_rate_functions``.
         """
         rates = [r(t,y) for r in self.birth_rate_functions]
@@ -932,7 +950,7 @@ class EpiModel(IntegrationMixin):
         -------
         get_event_rates : func
             A function that takes the current time ``t`` and
-            state vector ``y`` 
+            state vector ``y``
             and returns numerical event rate lists.
         get_compartment_changes : funx
             A function that takes a numerical list of event ``rates``

--- a/epipack/numeric_matrix_epi_models.py
+++ b/epipack/numeric_matrix_epi_models.py
@@ -2,7 +2,7 @@
 Provides an API to define Matrix epidemiological models.
 """
 
-import numpy as np 
+import numpy as np
 import scipy.sparse as sprs
 
 import warnings
@@ -24,7 +24,7 @@ from epipack.process_conversions import (
 
 class MatrixEpiModel(IntegrationMixin):
     """
-    A general class to define standard 
+    A general class to define standard
     mean-field compartmental
     epidemiological model.
 
@@ -43,7 +43,7 @@ class MatrixEpiModel(IntegrationMixin):
     N_comp : :obj:`int`
         Number of compartments (including population number)
     linear_rates : scipy.sparse.csr_matrix
-        Sparse matrix containing 
+        Sparse matrix containing
         transition rates of the linear processes.
     quadratic_rates : scipy.sparse.csr_matrix
         List of sparse matrices that contain
@@ -59,7 +59,7 @@ class MatrixEpiModel(IntegrationMixin):
     -------
 
     .. code:: python
-        
+
         >>> epi = MatrixEpiModel(["S","I","R"])
         >>> print(epi.compartments)
         [ "S", "I", "R" ]
@@ -81,7 +81,7 @@ class MatrixEpiModel(IntegrationMixin):
         self.correct_for_dynamical_population_size = correct_for_dynamical_population_size
         self.N_comp = len(self.compartments)
         self.birth_rates = np.zeros((self.N_comp,),dtype=np.float64)
-        self.linear_rates = sprs.csr_matrix((self.N_comp, self.N_comp),dtype=np.float64) 
+        self.linear_rates = sprs.csr_matrix((self.N_comp, self.N_comp),dtype=np.float64)
         self.quadratic_rates = [ sprs.csr_matrix((self.N_comp, self.N_comp),dtype=np.float64)\
                                  for c in range(self.N_comp) ]
 
@@ -93,8 +93,12 @@ class MatrixEpiModel(IntegrationMixin):
         """Get the compartment, given an integer ID ``iC``"""
         return self.compartments[iC]
 
-    def set_processes(self,process_list,allow_nonzero_column_sums=False,reset_rates=True,
-                      ignore_rate_position_checks=False):
+    def set_processes(self,
+                      process_list,
+                      allow_nonzero_column_sums=False,
+                      reset_rates=True,
+                      ignore_rate_position_checks=False,
+                      ):
         """
         Converts a list of reaction process tuples to rate tuples and sets the rates for this model.
 
@@ -136,11 +140,12 @@ class MatrixEpiModel(IntegrationMixin):
             turn this behavior off for transition, birth, death, and
             transmission processes. (Useful if you want to define
             symbolic transmission processes that are compartment-dependent).
-
-
         """
 
-        quadratic_rates, linear_rates = processes_to_rates(process_list, self.compartments,ignore_rate_position_checks)
+        quadratic_rates, linear_rates = processes_to_rates(process_list,
+                                                           self.compartments,
+                                                           ignore_rate_position_checks,
+                                                           )
         self.set_linear_rates(linear_rates,allow_nonzero_column_sums=allow_nonzero_column_sums)
         self.set_quadratic_rates(quadratic_rates,allow_nonzero_column_sums=allow_nonzero_column_sums)
 
@@ -171,7 +176,7 @@ class MatrixEpiModel(IntegrationMixin):
         Example
 
         reset_rates : bool, default : True
-            Whether to reset all linear rates to zero before 
+            Whether to reset all linear rates to zero before
             converting those.
         """
 
@@ -246,7 +251,10 @@ class MatrixEpiModel(IntegrationMixin):
 
         linear_rates = transition_processes_to_rates(process_list)
 
-        return self.set_linear_rates(linear_rates, reset_rates=False, allow_nonzero_column_sums=True)
+        return self.set_linear_rates(linear_rates,
+                                     reset_rates=False,
+                                     allow_nonzero_column_sums=True,
+                                     )
 
     def add_fission_processes(self,process_list):
         """
@@ -279,8 +287,11 @@ class MatrixEpiModel(IntegrationMixin):
         """
         linear_rates = fission_processes_to_rates(process_list)
 
-        return self.set_linear_rates(linear_rates, reset_rates=False, allow_nonzero_column_sums=True)
-    
+        return self.set_linear_rates(linear_rates,
+                                     reset_rates=False,
+                                     allow_nonzero_column_sums=True,
+                                     )
+
     def add_fusion_processes(self,process_list):
         """
         Define fusion processes between compartments.
@@ -312,28 +323,32 @@ class MatrixEpiModel(IntegrationMixin):
         """
         quadratic_rates = fusion_processes_to_rates(process_list)
 
-        return self.set_quadratic_rates(quadratic_rates, reset_rates=False, allow_nonzero_column_sums=True)
+        return self.set_quadratic_rates(quadratic_rates,
+                                        reset_rates=False,
+                                        allow_nonzero_column_sums=True
+                                        )
 
     def add_transmission_processes(self,process_list):
         r"""
-        A wrapper to define quadratic process rates through transmission reaction equations.
-        Note that in stochastic network/agent simulations, the transmission
+        A wrapper to define quadratic process rates through
+        transmission reaction equations. Note that in stochastic
+        network/agent simulations, the transmission
         rate is equal to a rate per link. For the mean-field ODEs,
-        the rates provided to this function will just be equal 
+        the rates provided to this function will just be equal
         to the prefactor of the respective quadratic terms.
 
         For instance, if you analyze an SIR system and simulate on a network of mean degree :math:`k_0`,
         a basic reproduction number :math:`R_0`, and a recovery rate :math:`\mu`,
-        you would define the single link transmission process as 
+        you would define the single link transmission process as
 
             .. code:: python
 
                 ("I", "S", R_0/k_0 * mu, "I", "I")
 
         For the mean-field system here, the corresponding reaction equation would read
-            
+
             .. code:: python
-                
+
                 ("I", "S", R_0 * mu, "I", "I")
 
         Parameters
@@ -344,11 +359,11 @@ class MatrixEpiModel(IntegrationMixin):
             .. code:: python
 
                 [
-                    ("source_compartment", 
+                    ("source_compartment",
                      "target_compartment_initial",
-                     rate 
-                     "source_compartment", 
-                     "target_compartment_final", 
+                     rate,
+                     "source_compartment",
+                     "target_compartment_final",
                      ),
                     ...
                 ]
@@ -367,7 +382,10 @@ class MatrixEpiModel(IntegrationMixin):
         """
         quadratic_rates = transmission_processes_to_rates(process_list)
 
-        return self.set_quadratic_rates(quadratic_rates, reset_rates=False, allow_nonzero_column_sums=True)
+        return self.set_quadratic_rates(quadratic_rates,
+                                        reset_rates=False,
+                                        allow_nonzero_column_sums=True,
+                                        )
 
     def add_quadratic_rates(self,rate_list,reset_rates=True,allow_nonzero_column_sums=False):
         """
@@ -375,7 +393,10 @@ class MatrixEpiModel(IntegrationMixin):
         See :func:`_tacoma.set_quadratic_rates` for docstring.
         """
 
-        return self.set_quadratic_rates(rate_list,reset_rates=False,allow_nonzero_column_sums=allow_nonzero_column_sums)
+        return self.set_quadratic_rates(rate_list,
+                                        reset_rates=False,
+                                        allow_nonzero_column_sums=allow_nonzero_column_sums,
+                                        )
 
     def add_linear_rates(self,rate_list,reset_rates=True,allow_nonzero_column_sums=False):
         """
@@ -383,8 +404,11 @@ class MatrixEpiModel(IntegrationMixin):
         See :func:`_tacoma.set_linear_rates` for docstring.
         """
 
-        return self.set_linear_rates(rate_list,reset_rates=False,allow_nonzero_column_sums=allow_nonzero_column_sums)
-    
+        return self.set_linear_rates(rate_list,
+                                     reset_rates=False,
+                                     allow_nonzero_column_sums=allow_nonzero_column_sums,
+                                     )
+
     def set_quadratic_rates(self,rate_list,reset_rates=True,allow_nonzero_column_sums=False):
         r"""
         Define the quadratic transition processes between compartments.
@@ -397,10 +421,11 @@ class MatrixEpiModel(IntegrationMixin):
             .. code:: python
 
                 [
-                    ("coupling_compartment_0",
-                     "coupling_compartment_1",
-                     "affected_compartment",
-                     rate
+                    (
+                      "coupling_compartment_0",
+                      "coupling_compartment_1",
+                      "affected_compartment",
+                      rate
                      ),
                     ...
                 ]
@@ -515,8 +540,10 @@ class MatrixEpiModel(IntegrationMixin):
 
     def get_jacobian_leading_eigenvalue(self,y0=None,returntype='complex'):
         """
-        Return leading eigenvalue of Jacobian at point ``y0``. Will use ``self.y0`` if argument ``y0`` is ``None``.
-        Use argument ``returntype='real'`` to only obtain the real part of the eigenvalue.
+        Return leading eigenvalue of Jacobian at point ``y0``.
+        Will use ``self.y0`` if argument ``y0`` is ``None``.
+        Use argument ``returntype='real'`` to only obtain the
+        real part of the eigenvalue.
         """
         J = self.jacobian(y0=y0)
         return self._get_leading_eigenvalue(J,returntype)
@@ -533,7 +560,8 @@ class MatrixEpiModel(IntegrationMixin):
             raise ValueError("No initial conditions have been given or set.")
 
         if self.correct_for_dynamical_population_size:
-            raise NotImplementedError("transmission matrices for models with varying population size have not been implemented.")
+            raise NotImplementedError("transmission matrices for models with "
+                                      "varying population size have not been implemented.")
 
         rows = []
         for M in self.quadratic_rates:
@@ -583,7 +611,8 @@ class MatrixEpiModel(IntegrationMixin):
         Sigma = (Sigma[use_comp,:])[:,use_comp]
         T = (T[use_comp,:])[:,use_comp]
 
-        K = -T.dot(sprs.linalg.inv(Sigma))
+        # convert Sigma to csc for more efficient inverse algo
+        K = -T.dot(sprs.linalg.inv(Sigma.tocsc()))
 
         return K
 
@@ -603,15 +632,19 @@ class MatrixEpiModel(IntegrationMixin):
 
     def _get_leading_eigenvalue(self,M,returntype='complex'):
 
-        # make sure that matrix is in CSC format (better for solver)
-        M_ = M.tocsc()
-        if M_.shape == (1,1):
-            _lambda = M_[0,0]
+        if M.shape == (1,1):
+            _lambda = M[0,0]
+        elif M.shape == (1,):
+            _lambda = M[0]
         else:
+            # I thought CSC format would be better for solver
+            # but it's not, so I uncommented this
+            # M_ = M.tocsc()
+            M_ = M
             if M_.shape == (2,2):
                 lambdas = np.linalg.eig(M_.toarray())[0]
             else:
-                lambdas = sprs.linalg.eigs(M_,k=min(2,M_.shape[0]-1),which='LR')[0]
+                lambdas = sprs.linalg.eigs(M_,k=min(2,M_.shape[0]-2),which='LR')[0]
             lambdas = sorted(lambdas, key=lambda x: -np.real(x))
             _lambda = lambdas[0]
         if returntype == 'real':

--- a/epipack/numeric_matrix_epi_models.py
+++ b/epipack/numeric_matrix_epi_models.py
@@ -605,9 +605,15 @@ class MatrixEpiModel(IntegrationMixin):
 
         # make sure that matrix is in CSC format (better for solver)
         M_ = M.tocsc()
-        lambdas = sprs.linalg.eigs(M_,k=min(2,M_.shape[0]),which='LR')[0]
-        lambdas = sorted(lambdas, key=lambda x: -np.real(x))
-        _lambda = lambdas[0]
+        if M_.shape == (1,1):
+            _lambda = M_[0,0]
+        else:
+            if M_.shape == (2,2):
+                lambdas = np.linalg.eig(M_.toarray())[0]
+            else:
+                lambdas = sprs.linalg.eigs(M_,k=min(2,M_.shape[0]-1),which='LR')[0]
+            lambdas = sorted(lambdas, key=lambda x: -np.real(x))
+            _lambda = lambdas[0]
         if returntype == 'real':
             _lambda = np.real(_lambda)
         return _lambda

--- a/epipack/plottools.py
+++ b/epipack/plottools.py
@@ -6,13 +6,12 @@ regularly and not supposed to be of great merit otherwise.
 Install matplotlib and bfmplot to use this module
 
 .. code::
-    
+
     matplotlib>=3.0.0
     bfmplot>=0.1.0
 """
 
-from bfmplot import pl
-import bfmplot as bp
+import matplotlib.pyplot as pl
 import matplotlib as mpl
 
 import numpy as np
@@ -21,6 +20,20 @@ from epipack.colors import hex_colors, palettes
 
 colors = [hex_colors[c] for c in  palettes['dark']]
 mpl.rcParams['axes.prop_cycle'] = mpl.cycler(color=colors)
+
+def strip_axis(ax,horizontal='right'):
+    """Remove the right and the top axis"""
+    if horizontal == 'right':
+        anti_horizontal = 'left'
+    else:
+        anti_horizontal = 'right'
+        ax.yaxis.set_label_position("right")
+
+    ax.spines[horizontal].set_visible(False)
+    ax.spines['top'].set_visible(False)
+
+    ax.yaxis.set_ticks_position(anti_horizontal)
+    ax.xaxis.set_ticks_position('bottom')
 
 def plot(t,result,ax=None, curve_label_format='{}',figsize=None):
     """
@@ -52,7 +65,7 @@ def plot(t,result,ax=None, curve_label_format='{}',figsize=None):
     for C, timeseries in result.items():
         ax.plot(t, timeseries, label=curve_label_format.format(str(C)))
         N += timeseries
-    bp.strip_axis(ax)
+    strip_axis(ax)
     ax.set_xlim([t.min(), t.max()])
     ax.set_ylim([0,N.max()])
     ax.set_xlabel('time')

--- a/epipack/process_conversions.py
+++ b/epipack/process_conversions.py
@@ -19,7 +19,7 @@ def processes_to_rates(process_list, compartments, ignore_rate_position_checks=F
 
                 # fission process
                 ( source_compartment, rate, target_compartment_0, target_ccompartment_1),
-                
+
                 # fusion process
                 ( source_compartment_0, source_compartment_1, rate, target_compartment),
 
@@ -31,9 +31,9 @@ def processes_to_rates(process_list, compartments, ignore_rate_position_checks=F
             ]
 
     compartments : :obj:`list` of hashable type
-        The compartments of these reaction equations. 
+        The compartments of these reaction equations.
     ignore_rate_position_checks : bool, default = False
-        This function usually checks whether the rate of 
+        This function usually checks whether the rate of
         a reaction is positioned correctly. You can
         turn this behavior off for transition, birth, death, and
         transmission processes. (Useful if you want to define
@@ -171,13 +171,13 @@ def fission_processes_to_rates(process_list):
     """
 
     linear_rates = []
-    
+
     for source, rate, target0, target1 in process_list:
 
         _s = source
         _t0 = target0
         _t1 = target1
-        
+
         # source compartment loses an entity
         # target compartments gains one each
         linear_rates.append((_s, _s, -rate))
@@ -217,9 +217,9 @@ def fusion_processes_to_rates(process_list):
     """
 
     quad_rates = []
-    
+
     for source0, source1, rate, target in process_list:
-        
+
         # target compartment gains one entity
         quad_rates.append((source0, source1, target, rate))
         # source compartments lose one entity each
@@ -245,9 +245,9 @@ def transmission_processes_to_rates(process_list):
             ("I", "S", R_0/k_0 * mu, "I", "I")
 
     For the mean-field system here, the corresponding reaction equation would read
-        
+
         .. code:: python
-            
+
             ("I", "S", R_0 * mu, "I", "I")
 
     Parameters
@@ -258,11 +258,11 @@ def transmission_processes_to_rates(process_list):
         .. code:: python
 
             [
-                (source_compartment, 
+                (source_compartment,
                  target_compartment_initial,
-                 rate 
-                 source_compartment, 
-                 target_compartment_final, 
+                 rate
+                 source_compartment,
+                 target_compartment_final,
                  ),
                 ...
             ]
@@ -292,7 +292,7 @@ def transmission_processes_to_rates(process_list):
 
         reactants = [_s0, _s1]
         products = [_t0, _t1]
-        constant = (set.intersection(set(reactants), set(products)))        
+        constant = (set.intersection(set(reactants), set(products)))
         if len(constant) == 2 or tuple(reactants) == tuple(products):
             raise ValueError("Process "+\
                              str((coupling0, coupling1, rate, affected0, affected1)) +\

--- a/epipack/stochastic_epi_models.py
+++ b/epipack/stochastic_epi_models.py
@@ -414,7 +414,7 @@ class StochasticEpiModel():
             else:
                 raise ValueError("Only node transition or link transmission events are "
                                  "allowed to trigger conditional link transmission events "
-                                 '(invalid event: "'+ triggering_event+'"')
+                                 '(invalid event: "'+ str(triggering_event) +'"')
 
             event = (_c0, _s, _t)
             self.conditional_link_transmission_events[event] = {}

--- a/epipack/symbolic_epi_models.py
+++ b/epipack/symbolic_epi_models.py
@@ -57,10 +57,10 @@ class SymbolicMixin():
         Parameters
         ----------
         simplify : bool, default = True
-            If ``True``, `epipack` will try to simplify 
+            If ``True``, `epipack` will try to simplify
             the evaluated Jacobian. This might not be
             desirable in some cases due to its
-            long evaluation time, which is why 
+            long evaluation time, which is why
             it can be turned off.
         """
 
@@ -551,9 +551,11 @@ class SymbolicEpiModel(SymbolicMixin, EpiModel):
                 birth_event_updates.append( dy )
                 birth_rate_functions.append( rate )
             else:
-                _s = self.get_compartment_id(acting_compartments[0])
+                # check if compartment was defined as a function
+                this_compartment = acting_compartments[0]
+
                 self._check_rate_for_functional_dependency(rate)
-                this_rate = rate * acting_compartments[0]
+                this_rate = rate * this_compartment
                 linear_event_updates.append( dy )
                 linear_rate_functions.append( this_rate )
 

--- a/epipack/tests/distributions_tests.py
+++ b/epipack/tests/distributions_tests.py
@@ -1,0 +1,36 @@
+import unittest
+
+import numpy as np
+from scipy.optimize import root
+
+from epipack.distributions import (
+            ExpChain,
+            fit_chain_by_cdf,
+            fit_chain_by_median_and_iqr,
+        )
+
+class DistributionsTest(unittest.TestCase):
+
+    def test_init(self):
+
+        times = [0.3,6.,9,0.4]
+        C = ExpChain(times)
+        assert(np.isclose(sum(times), C.get_mean()))
+
+    def test_fit(self):
+
+        times = [0.3,6.,9,0.4]
+        C = ExpChain(times)
+        fit_C = fit_chain_by_median_and_iqr(3,*C.get_median_and_iqr())
+
+        medA, (iqrA0, iqrA1) = C.get_median_and_iqr()
+        medF, (iqrF0, iqrF1) = fit_C.get_median_and_iqr()
+
+        assert(np.isclose(medA, medF,rtol=1e-3))
+        assert(np.isclose(iqrA0, iqrF0,rtol=1e-3))
+        assert(np.isclose(iqrA1, iqrF1,rtol=1e-3))
+
+if __name__=="__main__":
+    T = DistributionsTest()
+    T.test_init()
+    T.test_fit()

--- a/epipack/tests/temporal_network_tests.py
+++ b/epipack/tests/temporal_network_tests.py
@@ -97,7 +97,7 @@ class TemporalNetworkTest(unittest.TestCase):
             pl.hist(taus,bins=100,density=True)
             pl.plot(tt, rates*np.exp(-I2))
             pl.show()
-        assert(entropy(theory, experi) < 0.01)
+        assert(entropy(theory, experi) < 0.02)
 
     def test_degree(self):
 

--- a/epipack/vis.py
+++ b/epipack/vis.py
@@ -29,7 +29,7 @@ class SimulationStatus():
         Number of nodes
     sampling_dt : float
         The amount of simulation time that's supposed
-        to pass during a single update        
+        to pass during a single update
 
     Attributes
     ==========
@@ -37,7 +37,7 @@ class SimulationStatus():
         An array containing node statuses of the previous update
     sampling_dt : float
         The amount of simulation time that's supposed
-        to pass during a single update        
+        to pass during a single update
     simulation_ended : bool
         Whether or not the simulation is over
     paused : bool
@@ -198,7 +198,7 @@ class App(pyglet.window.Window):
         glLoadIdentity()
         glOrtho( self.left, self.right, self.bottom, self.top, 1, -1 )
 
-    
+
     def on_key_press(self, symbol, modifiers):
         """
         Check for keyboard input.
@@ -229,7 +229,7 @@ class App(pyglet.window.Window):
         elif symbol == key.SPACE:
             self.simulation_status.paused = not self.simulation_status.paused
 
-    
+
 
 class Scale():
     """
@@ -271,7 +271,7 @@ class Scale():
     """
 
     def __init__(self,bound_increase_factor=1.0):
-        
+
         self.x0 = np.nan
         self.y0 = np.nan
         self.x1 = np.nan
@@ -333,7 +333,7 @@ class Scale():
             _x = self.mx * (x-self.x0) + self.left
 
         return _x
-        
+
     def scaley(self,y):
         """
         Scale y-data
@@ -381,7 +381,7 @@ class Scale():
         Append an object that depends on this Scale instance.
         """
         self.scaling_objects.append(obj)
-        
+
 
 
 class Curve():
@@ -560,8 +560,8 @@ def get_network_batch(stylized_network,
     network_objects : dict
         A dictionary containing all the necessary objects to draw and
         update the network.
-        
         - `lines` : a list of pyglet-line objects (one entry per link)
+
         - `disks` : a list of pyglet-circle objects (one entry per node)
         - `circles` : a list of pyglet-circle objects (one entry per node)
         - `nodes_to_lines` : a dictionary mapping a node to a list of
@@ -618,7 +618,7 @@ def get_network_batch(stylized_network,
                                       color=tuple(bytes.fromhex(node['color'][1:])),
                                       batch=batch,
                                       )
-                        
+
                 circles[node['id']] = \
                         shapes.Arc(node['x_canvas'],
                                       node['y_canvas']+yoffset,
@@ -642,7 +642,7 @@ def get_network_batch(stylized_network,
 
 _default_config = {
             'plot_sampled_curve': True,
-            'draw_links':True,            
+            'draw_links':True,
             'draw_nodes':True,
             'n_circle_segments':16,
             'plot_height':120,
@@ -736,7 +736,7 @@ def visualize(model,
 
             _default_config = {
                         'plot_sampled_curve': True,
-                        'draw_links':True,            
+                        'draw_links':True,
                         'draw_nodes':True,
                         'n_circle_segments':16,
                         'plot_height':120,
@@ -772,7 +772,7 @@ def visualize(model,
             cfg['bgcolor'] = col.hex_bg_colors[palette]
         if 'compartment_colors' not in cfg:
             cfg['compartment_colors'] = [ col.colors[this_color] for this_color in col.palettes[palette] ]
-        
+
     bgcolor = [ _/255 for _ in list(bytes.fromhex(cfg['bgcolor'][1:])) ] + [1.0]
 
     bgY = 0.2126*bgcolor[0] + 0.7152*bgcolor[1] + 0.0722*bgcolor[2]
@@ -781,7 +781,7 @@ def visualize(model,
             cfg['legend_font_color'] = '#fafaef'
         else:
             cfg['legend_font_color'] = '#232323'
-        
+
     width = network['xlim'][1] - network['xlim'][0]
     height = network['ylim'][1] - network['ylim'][0]
 
@@ -815,7 +815,7 @@ def visualize(model,
         # the demanded height or the legend height
         if with_plot:
             plot_height = max(plot_height, legend_height)
-        legend_y_offset = legend_height            
+        legend_y_offset = legend_height
 
         max_text_width = 0
         legend_objects = [] # this is a hack so that the garbage collector doesn't delete our stuff 
@@ -842,7 +842,7 @@ def visualize(model,
                                       color = cfg['compartment_colors'][iC],
                                       batch=legend_batch,
                                       )
-                        
+
                 circle = shapes.Arc(this_x,
                                       this_y - (dy-1.25*legend_circle_radius)/2,
                                       legend_circle_radius,
@@ -862,7 +862,7 @@ def visualize(model,
             #                          )
             #    legend_objects.append(rect)
 
-            max_text_width = max(max_text_width, label.content_width)        
+            max_text_width = max(max_text_width, label.content_width)
 
         legend_width =   2*cfg['padding'] \
                        + 2*legend_circle_radius \
@@ -977,7 +977,7 @@ def visualize(model,
 
         # get sampling_dt
         sampling_dt = simstate.sampling_dt
-        
+
         # Advance the simulation until time sampling_dt.
         # sim_time is a numpy array including all time values at which
         # the system state changed. The first entry is the initial state
@@ -1024,11 +1024,11 @@ def visualize(model,
                     # and append the whole dataset
                     val = (v[1:].tolist() + [v[-1]])
                     curves[k].append_list(this_time, val)
-                
+
 
         # iterate through the nodes that have to be updated
         for node in ndx:
-            status = model.node_status[node]    
+            status = model.node_status[node]
             if cfg['draw_nodes']:
                 disks[node].color = cfg['compartment_colors'][status]
 
@@ -1062,7 +1062,7 @@ def visualize(model,
 
 def visualize_reaction_diffusion(
               model,
-              network, 
+              network,
               sampling_dt,
               node_compartments,
               value_extent=[0.0,1.0],
@@ -1107,12 +1107,12 @@ def visualize_reaction_diffusion(
                 ]
             }
 
-    sampling_dt : float 
+    sampling_dt : float
         The amount of simulation time that's supposed to pass
         with a single update.
     quarantine_compartments: list
         List of compartment objects that are supposed to be
-        resemble quarantine (i.e. temporarily 
+        resemble quarantine (i.e. temporarily
         losing all connections)
     node_compartments: list
         The compartments for which to display the concentrations.
@@ -1122,13 +1122,13 @@ def visualize_reaction_diffusion(
     config : dict, default = None
         A dictionary containing all possible configuration
         options. Entries in this dictionary will overwrite
-        the default config which is 
+        the default config which is
 
         .. code:: python
 
             _default_config = {
                         'plot_sampled_curve': True,
-                        'draw_links':True,            
+                        'draw_links':True,
                         'draw_nodes':True,
                         'n_circle_segments':16,
                         'plot_height':120,
@@ -1157,7 +1157,7 @@ def visualize_reaction_diffusion(
         cfg.update(config)
 
     bgcolor = [ _/255 for _ in list(bytes.fromhex(cfg['bgcolor'][1:])) ] + [1.0]
-        
+
     width = network['xlim'][1] - network['xlim'][0]
     height = network['ylim'][1] - network['ylim'][0]
 
@@ -1196,7 +1196,7 @@ def visualize_reaction_diffusion(
 
     # handle different strokewidths
     if 'nodeStrokeWidth' in network:
-        node_stroke_width = network['nodeStrokeWidth'] 
+        node_stroke_width = network['nodeStrokeWidth']
     else:
         node_stroke_width = cfg['node_stroke_width']
 
@@ -1223,7 +1223,7 @@ def visualize_reaction_diffusion(
     def _get_opacity(val,this_cmin,this_cmax):
         opacity = (val-this_cmin)/(this_cmax-this_cmin) + this_cmin
         if opacity > 1.0:
-            opacity = 1.0        
+            opacity = 1.0
         if opacity < 0.0:
             opacity = 0.0
         return int(255*opacity)
@@ -1247,7 +1247,7 @@ def visualize_reaction_diffusion(
 
         # get sampling_dt
         sampling_dt = simstate.sampling_dt
-        
+
         # Advance the simulation until time sampling_dt.
         # `sim_result` is a two-dimensional array
         # where index sim_result[iC, iT] gives the

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,3 @@ pyglet>=1.5.15,<1.6
 ipython>=7.14.0
 ipywidgets>=7.5.1
 matplotlib>=3.0.0
-bfmplot>=0.0.7

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
                 'ipython>=7.14.0',
                 'ipywidgets>=7.5.1',
                 'matplotlib>=3.0.0',
-                'bfmplot>=0.0.7',
     ],
     tests_require=['pytest', 'pytest-cov'],
     setup_requires=['pytest-runner'],


### PR DESCRIPTION
### Added

- A new small-world network styling method based on 1d lattice distance (in epipack.networks)
- methods to compute Jacobian and next generation matrices (NGMs) in `MatrixEpiModel`, as well as R0 from said NGMs (TODO: add docs)
- tests for these methods
- `epipack.distributions` module, which deals with fitting empirical distributions to sums of exponentially distributed random variables (still in dev mode, also TODO: add docs)
- tests for this module
- methods to `EpiModel` that save events that have been set. This will be used to generate model flowcharts with graphviz at some point
- the possibility to pass a function to ``StochasticEpiModel.simulate`` that checks for a custom stop condition